### PR TITLE
Hack around glint problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,16 @@
   },
   "packageManager": "pnpm@8.9.0",
   "pnpm": {
+    "packageExtensions": {
+      "@glint/environment-ember-template-imports": {
+        "dependencies": {
+          "ember-template-imports": "^3.0.0"
+        },
+        "peerDependencies": {
+          "ember-template-imports": null
+        }
+      }
+    },
     "overrides": {
       "@glimmer/component": "^1.1.2",
       "@glimmer/tracking": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-qunit": "^8.0.2",
     "ember-resolver": "^11.0.1",
     "ember-source": "~5.4.0",
-    "ember-template-imports": "^3.4.2",
+    "ember-template-imports": "^4.0.0",
     "ember-template-lint": "^5.12.0",
     "ember-truth-helpers": "^4.0.3",
     "eslint": "^8.53.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ devDependencies:
     version: 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
   '@glint/environment-ember-template-imports':
     specifier: ^1.2.1
-    version: 1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@3.4.2)
+    version: 1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@4.0.0)
   '@glint/template':
     specifier: ^1.2.1
     version: 1.2.1
@@ -159,8 +159,8 @@ devDependencies:
     specifier: ~5.4.0
     version: 5.4.0(@babel/core@7.23.3)(@glimmer/component@1.1.2)(@glint/template@1.2.1)(rsvp@4.8.5)(webpack@5.89.0)
   ember-template-imports:
-    specifier: ^3.4.2
-    version: 3.4.2
+    specifier: ^4.0.0
+    version: 4.0.0
   ember-template-lint:
     specifier: ^5.12.0
     version: 5.12.0
@@ -2110,7 +2110,7 @@ packages:
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.1.0(ember-source@5.4.0)
 
-  /@glint/environment-ember-template-imports@1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@3.4.2):
+  /@glint/environment-ember-template-imports@1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@4.0.0):
     resolution: {integrity: sha512-yTuF8oQyvVKmU3fCuYtg8Gf02VghQYI36x5/eob6yaMx2M+p3MFO+E6X7ANz/1bYRXphEPTWQMgdDjM4C6Ql4A==}
     peerDependencies:
       '@glint/environment-ember-loose': 1.2.1
@@ -2132,7 +2132,7 @@ packages:
     dependencies:
       '@glint/environment-ember-loose': 1.2.1(@glimmer/component@1.1.2)(@glint/template@1.2.1)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
       '@glint/template': 1.2.1
-      ember-template-imports: 3.4.2
+      ember-template-imports: 4.0.0
     dev: true
 
   /@glint/template@1.2.1:
@@ -5110,6 +5110,10 @@ packages:
       safe-buffer: 5.2.1
     dev: true
 
+  /content-tag@1.1.2:
+    resolution: {integrity: sha512-AZkfc6TUmW+/RbZJioPzOQPAHHXqyqK4B0GNckJDjBAPK3SyGrMfn21bfFky/qwi5uoLph5sjAHUkO3CL6/IgQ==}
+    dev: true
+
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -6333,6 +6337,17 @@ packages:
       parse-static-imports: 1.1.0
       string.prototype.matchall: 4.0.10
       validate-peer-dependencies: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ember-template-imports@4.0.0:
+    resolution: {integrity: sha512-Kw1FnFX3MrBesfsjJDFvVgOf1mANOvMprAH1ngDd5SvdlkltNWCF2UKI9WXKQV3lw5noQC1+n6S80L9Q03D3Hw==}
+    engines: {node: 16.* || >= 18}
+    dependencies:
+      broccoli-stew: 3.0.0
+      content-tag: 1.1.2
+      ember-cli-version-checker: 5.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ overrides:
   '@glint/environment-ember-template-imports': ^1.2.1
   '@glint/template': ^1.2.1
 
+packageExtensionsChecksum: d918d28f2821b53af9dde87dfda25624
+
 dependencies:
   '@embroider/macros':
     specifier: ^1.13.3


### PR DESCRIPTION
Glint needs to use `content-tag`, because `ember-template-imports@v4` removed all the APIs Glint was using from `ember-template-imports@v3`.



This is tracked here: https://github.com/typed-ember/glint/issues/609


_Of note_,
this app has `auto-install-peers=true` set.