### PR TITLE
Add ESLint to historical tracking

### DIFF
--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -33,6 +33,7 @@ ember-cli-mirage
 ###############
 # Generic JS
 ###############
+eslint
 execa
 rollup
 typescript


### PR DESCRIPTION
ESLint recently had a new major, v9.

I'm curious how ecosystem why migration progresses, since v9 requires a new config format (the "flat config" (different from using only overrides in ESLint < v9))