### PR TITLE
Add ember-cli-babel to the list of tracked packages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 # unconventional js
 /blueprints/*/files/
 public/history
+public/
 
 # compiled output
 /dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 /blueprints/*/files/
 app/templates/*.gts
 public/history/
+public/
 
 # compiled output
 /dist/

--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -14,6 +14,7 @@ export const PACKAGES = `
 ember-source
 ember-data
 ember-cli
+ember-cli-babel
 @ember/test-helpers
 @ember/test-waiters
 


### PR DESCRIPTION
ember-cli-babel is what is used for v1 apps and v1 addons to transpile code to native JavaScript.
in particular, it is responsible for handling TypeScript, and decorators.

Tracking history over time will be useful as this library has had a number of majors over the years.