### PR TITLE
Add `wrangler` to historical tracking

### DIFF
--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -51,6 +51,7 @@ jasmine-core
 mocha
 qunit
 qunitjs
+wrangler
 
 ###############
 # React


### PR DESCRIPTION
We recently released a v4 of [Wrangler](https://www.npmjs.com/package/wrangler)—it would be great to be able to track adoption over time of v3 vs v4.