### PR TITLE
feat: track history of vite-plugin-svelte

### DIFF
--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -75,6 +75,7 @@ solid-js
 ###############
 svelte
 @sveltejs/kit
+@sveltejs/vite-plugin-svelte
 
 ###############
 # Vue


### PR DESCRIPTION
This would help with tracking the update rate after the recent v6 release. 

The download numbers for bundler plugins can offer interesting insights on a lower level than main packages or their meta-frameworks, so maybe adding others as well would be good too.