### PR TITLE
Track versions of fast-check

### DIFF
--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -53,6 +53,7 @@ mocha
 qunit
 qunitjs
 wrangler
+fast-check
 
 ###############
 # React


### PR DESCRIPTION
I'm the author of the library [fast-check ](https://fast-check.dev) and would be interested into having more insights on its usage.

While using your tool, I found this note:

>  History for each packages is currently tracked manually in a cronjob. If you'd like to see a package's history tracked, please open a PR similar to
this example PR.

So I gave it a try and opened this PR to suggest fast-check.

Thanks in advance 👍