### PR TITLE
Fix history tooltip dropping versions on the right of the graph

### DIFF
--- a/app/templates/query/graphing/history/chart.ts
+++ b/app/templates/query/graphing/history/chart.ts
@@ -65,9 +65,20 @@ export function sortByWeek<Datum extends { week: string }>(data: Datum[]) {
   });
 }
 
+/**
+ * chart.js' `index` interaction mode looks points up by their position within
+ * each dataset's data array, not by their x-value. A version is only present in
+ * the data for the weeks it was above the 1% cutoff, so without padding, every
+ * dataset would have its own length and the tooltip would read the wrong week
+ * (or nothing at all) out of the shorter ones.
+ */
+export function alignToLabels(byTime: { [yearWeek: string]: number }, labels: string[]) {
+  return labels.map((week) => ({ week, count: byTime[week] ?? null }));
+}
+
 const increments = [0.1, 0.2, 0.3, 0.4, 0.5];
 
-function datasetsFor(data: ReshapedHistoricalData) {
+function datasetsFor(data: ReshapedHistoricalData, labels: string[]) {
   const result = [];
   const packageNames = Object.keys(data);
   const numPackages = packageNames.length;
@@ -110,11 +121,8 @@ function datasetsFor(data: ReshapedHistoricalData) {
         pointHoverBorderWidth: 5,
         hoverBorderWidth: 7,
         borderColor: color,
-        data: sortByWeek(
-          Object.entries(byTime).map(([week, count]) => {
-            return { week, count };
-          })
-        ),
+        spanGaps: true,
+        data: alignToLabels(byTime, labels),
       });
     }
   }
@@ -137,7 +145,7 @@ export function createChart(
     colorScheme.current === 'dark' ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)';
 
   const labels = sortLabels(data);
-  const datasets = datasetsFor(data);
+  const datasets = datasetsFor(data, labels);
 
   // Add a line annotation for each package's total downloads
   if (showTotal) {
@@ -147,13 +155,6 @@ export function createChart(
       const packageTotals = totals[packageName];
 
       if (!packageTotals) continue;
-
-      // Create data points for the total line
-      const totalPoints = sortByWeek(
-        Object.entries(packageTotals).map(([week, count]) => {
-          return { week, count };
-        })
-      );
 
       // Add the total as a dataset instead of annotation for better interactivity
       datasets.push({
@@ -166,7 +167,8 @@ export function createChart(
         pointRadius: 0,
         pointHoverRadius: 4,
         pointHoverBorderWidth: 2,
-        data: totalPoints,
+        spanGaps: true,
+        data: alignToLabels(packageTotals, labels),
         order: -1, // Draw on top
       });
     }

--- a/tests/unit/alignToLabels-test.ts
+++ b/tests/unit/alignToLabels-test.ts
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+
+import { alignToLabels } from 'package-majors/templates/query/graphing/history/chart';
+
+const labels = ['2025, week 1', '2025, week 2', '2025, week 3', '2025-01-20'];
+
+module('Unit | alignToLabels', () => {
+  test('a version present for every label', (assert) => {
+    const result = alignToLabels(
+      {
+        '2025, week 1': 1,
+        '2025, week 2': 2,
+        '2025, week 3': 3,
+        '2025-01-20': 4,
+      },
+      labels
+    );
+
+    assert.deepEqual(result, [
+      { week: '2025, week 1', count: 1 },
+      { week: '2025, week 2', count: 2 },
+      { week: '2025, week 3', count: 3 },
+      { week: '2025-01-20', count: 4 },
+    ]);
+  });
+
+  test('a version that appears late still lines up with the labels', (assert) => {
+    const result = alignToLabels({ '2025, week 3': 3, '2025-01-20': 4 }, labels);
+
+    assert.deepEqual(result, [
+      { week: '2025, week 1', count: null },
+      { week: '2025, week 2', count: null },
+      { week: '2025, week 3', count: 3 },
+      { week: '2025-01-20', count: 4 },
+    ]);
+  });
+
+  test('a version that drops in and out keeps its gaps', (assert) => {
+    const result = alignToLabels({ '2025, week 1': 1, '2025, week 3': 3 }, labels);
+
+    assert.deepEqual(result, [
+      { week: '2025, week 1', count: 1 },
+      { week: '2025, week 2', count: null },
+      { week: '2025, week 3', count: 3 },
+      { week: '2025-01-20', count: null },
+    ]);
+  });
+
+  test('a count of 0 is kept', (assert) => {
+    const result = alignToLabels({ '2025, week 2': 0 }, ['2025, week 2']);
+
+    assert.deepEqual(result, [{ week: '2025, week 2', count: 0 }]);
+  });
+});


### PR DESCRIPTION
Hovering the right-hand side of the history graph left versions out of the tooltip. On `?packages=ember-source` today, hovering `2026, week 31` showed v3–v6 but not v7, even though v7 had 59,675 downloads that week.

### Cause

chart.js' `index` interaction mode looks points up by their **position in each dataset's data array**, not by their x-value. `reshape` only gives a version a data point for the weeks it was above the 1% cutoff, so the datasets have different lengths:

| dataset | points | labels |
| --- | --- | --- |
| v2 | 12 (sparse) | 46 |
| v3–v6 | 46 | 46 |
| v7 | 19 (starts week 14) | 46 |

Hovering label index 44 asks every dataset for `data[44]`, which v2 and v7 don't have — so they vanish. Left of the graph it's worse than missing rows: hovering `2025, week 37` reported v2's week-43 number and a v7 number from `2026, week 19`, a week v7 didn't exist yet, and took the tooltip title from the misaligned point.

### Fix

Pad every dataset out to the full label list, using `null` for weeks a version has no data. Array index now equals label index, so chart.js reads the right week from every dataset, and it skips the `null` points (`element.skip`) so versions genuinely absent that week stay out of the tooltip. `spanGaps: true` keeps the lines drawn straight through gaps, which is how they render today.

Applies to the `total` datasets too — they were also shorter than the label list.

### Verified

Same hover position (`2026, week 31`), before → after:

- before: v3 150,218 (36.1%) · v4 55,871 (13.4%) · v5 90,876 (21.9%) · v6 118,853 (28.6%)
- after: v3 150,218 (31.6%) · v4 55,871 (11.8%) · v5 90,876 (19.1%) · v6 118,853 (25.0%) · **v7 59,675 (12.6%)**

Percentages shift because the denominator was missing v7. Also checked `?packages=ember-source,ember-data&showTotal=true` — all 13 datasets align, and every tooltip row matches the hovered week.

`pnpm lint` and `pnpm test` pass; added 4 unit tests for the padding helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)